### PR TITLE
Use `rouge` for highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-highlighter: pygments
+highlighter: rouge
 
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.


### PR DESCRIPTION
Got this warning email from Github :

> The page build completed successfully, but returned the following warning:
> You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml'. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.
> GitHub Pages was recently upgraded to Jekyll 3.0. It may help to confirm you're using the correct dependencies:
> https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
> For information on troubleshooting Jekyll see:
> https://help.github.com/articles/using-jekyll-with-pages#troubleshooting
> If you have any questions you can contact us by replying to this email.
